### PR TITLE
Feat: Changes table layout to better fit space available

### DIFF
--- a/inst/app/www/css/style.css
+++ b/inst/app/www/css/style.css
@@ -58,13 +58,17 @@ a {
   z-index: 9999;
 }
 
-table:not(.dataTable) thead tr{
+table:not(.dataTable) thead tr {
   color: white;
   background-color: #005EB8CC;
 }
 
-table:not(.dataTable) tbody:nth-child(odd){
+table:not(.dataTable) tbody:nth-child(odd) {
   background-color: #005EB81F;
+}
+
+table.dataTable th {
+  font-size: 12px;
 }
 
 /* Remove everything except y-axis and labels and text for first chart */


### PR DESCRIPTION
- Change is basically to group each pair of columns per FY
- Is temporary 'fix' for now - it will not handle even one additional year

One suggestion is to show just one FY worth of data at a time, so the existing FY dropdown will affect table as well as map. This is probably the cleanest solution, but does lose that longitudinal view of multiple years in view at once.